### PR TITLE
Allow format switching on Import

### DIFF
--- a/src/Decksteria.Services/Deckbuilding/DeckbuildingService.cs
+++ b/src/Decksteria.Services/Deckbuilding/DeckbuildingService.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Dynamic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,6 +23,8 @@ internal sealed class DeckbuildingService<T> : IDeckbuildingService<T>
     public IEnumerable<DecksteriaDeck> DeckInformation => format.Decks.Select(f => new DecksteriaDeck(f));
 
     public string GameTitle => game.DisplayName;
+
+    public string FormatName => format.Name;
 
     public string FormatTitle => format.DisplayName;
 

--- a/src/Decksteria.Services/Deckbuilding/DeckbuildingServiceFactory.cs
+++ b/src/Decksteria.Services/Deckbuilding/DeckbuildingServiceFactory.cs
@@ -1,0 +1,30 @@
+﻿namespace Decksteria.Services.Deckbuilding;
+
+using System;
+using Decksteria.Core;
+using Decksteria.Services.PlugInFactory;
+using Decksteria.Services.PlugInFactory.Models;
+
+internal sealed class DeckbuildingServiceFactory : IDeckbuildingServiceFactory
+{
+    private readonly IDecksteriaPlugInFactory plugInFactory;
+
+    private GameFormat currentGameFormat;
+
+    public DeckbuildingServiceFactory(IDecksteriaPlugInFactory plugInFactory)
+    {
+        this.plugInFactory = plugInFactory;
+        currentGameFormat = plugInFactory.GetSelectedFormat();
+    }
+
+    public void ChangeFormat(string formatName)
+    {
+        plugInFactory.SelectGame(currentGameFormat.GameName, formatName);
+        currentGameFormat = plugInFactory.GetSelectedFormat();
+    }
+
+    public IDeckbuildingService GetCurrentDeckbuildingService()
+    {
+        return new DeckbuildingService<IDecksteriaFormat>(currentGameFormat.Game, currentGameFormat.Format);
+    }
+}

--- a/src/Decksteria.Services/Deckbuilding/IDeckbuildingService.cs
+++ b/src/Decksteria.Services/Deckbuilding/IDeckbuildingService.cs
@@ -13,6 +13,8 @@ public interface IDeckbuildingService
 
     string GameTitle { get; }
 
+    string FormatName { get; }
+
     string FormatTitle { get; }
 
     Task<bool> AddCardAsync(CardArt card, string? deckName = null, CancellationToken cancellationToken = default);

--- a/src/Decksteria.Services/Deckbuilding/IDeckbuildingServiceFactory.cs
+++ b/src/Decksteria.Services/Deckbuilding/IDeckbuildingServiceFactory.cs
@@ -1,0 +1,8 @@
+﻿namespace Decksteria.Services.Deckbuilding;
+
+public interface IDeckbuildingServiceFactory
+{
+    void ChangeFormat(string formatName);
+
+    IDeckbuildingService GetCurrentDeckbuildingService();
+}

--- a/src/Decksteria.Services/DependencyInjection.cs
+++ b/src/Decksteria.Services/DependencyInjection.cs
@@ -1,9 +1,7 @@
 ﻿namespace Decksteria.Services;
 
-using Decksteria.Core;
 using Decksteria.Services.Deckbuilding;
 using Decksteria.Services.DeckFileService;
-using Decksteria.Services.PlugInFactory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -17,12 +15,7 @@ public static class DependencyInjection
 
     public static IServiceCollection AddDeckbuildingServices(this IServiceCollection services)
     {
-        services.TryAddScoped<IDeckbuildingService>(options =>
-        {
-            var pluginFactory = options.GetRequiredService<IDecksteriaPlugInFactory>();
-            var gameFormat = pluginFactory.GetSelectedFormat();
-            return new DeckbuildingService<IDecksteriaFormat>(gameFormat.Game, gameFormat.Format);
-        });
+        services.TryAddScoped<IDeckbuildingServiceFactory, DeckbuildingServiceFactory>();
         return services;
     }
 }

--- a/src/Decksteria.Services/PlugInFactory/IDecksteriaPlugInFactory.cs
+++ b/src/Decksteria.Services/PlugInFactory/IDecksteriaPlugInFactory.cs
@@ -9,7 +9,7 @@ public interface IDecksteriaPlugInFactory
 
     GameFormat GetSelectedFormat();
 
-    void SelectGame(string gameName, string formatNaame);
+    void SelectGame(string gameName, string formatName);
 
     bool TryAddGame(string dllFilePath);
 }


### PR DESCRIPTION
## Type of change
* New feature
* Bug fix

Changes:
-  To prevent crashing when a deck that doesn't support the current format is imported, allow switching formats.

## Tests
* Ran locally on Windows and Android.

## Checklist:
Please delete options that are not relevant.

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
